### PR TITLE
Fix packing TimeSpan values. Related to Fallen-8 issue #17.

### DIFF
--- a/Serialization/SerializationWriter.cs
+++ b/Serialization/SerializationWriter.cs
@@ -86,7 +86,7 @@ namespace Framework.Serialization
 		internal static readonly BitVector32.Section HoursSection = BitVector32.CreateSection(23, HasMillisecondsSection); // 5 bits
 		internal static readonly BitVector32.Section MinutesSection = BitVector32.CreateSection(59, HoursSection); // 6 bits  total = 2 bytes
 		internal static readonly BitVector32.Section SecondsSection = BitVector32.CreateSection(59, MinutesSection); // 6 bits total = 3 bytes
-		internal static readonly BitVector32.Section MillisecondsSection = BitVector32.CreateSection(1024, SecondsSection); // 10 bits - total 31 bits = 4 bytes
+		internal static readonly BitVector32.Section MillisecondsSection = BitVector32.CreateSection(999, SecondsSection); // 10 bits - total 31 bits = 4 bytes
 
 		/// <summary>
 		/// Holds the highest Int16 that can be optimized into less than the normal 2 bytes


### PR DESCRIPTION
Hi!

I've looking today through Fallen-8 Graph DB.

I found out that saving is broken. I checked out previous commit (with Tests). All passed except persistency tests that failed somewhere in Vector32.

It took no long to found out that problem was in milliseconds. 1024 is 11 bits (adding zero you get 1025 different values).

I've fixed and run tests. All passed.

P.S. Could you please answer one question. I've noticed that persistency test with randomGraphs  requires too much memory. 100000 \* 20 / 2 = 10e6 objects. They requires 20Gb on disk. So approx. 20Kb per object. Why so much?

Ilya
